### PR TITLE
Fix progress indicator stuck after save

### DIFF
--- a/composeApp/src/commonMain/kotlin/feature/create/presentation/ComposeViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/feature/create/presentation/ComposeViewModel.kt
@@ -69,6 +69,7 @@ class ComposeViewModel : BaseViewModel<ComposeViewState, ComposeAction, ComposeE
                 )
 
                 withContext(Dispatchers.Main) {
+                    viewState = viewState.copy(isSending = false)
                     viewAction = ComposeAction.Success
                 }
             } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- reset `isSending` flag to `false` when habit creation succeeds so the progress indicator disappears

## Testing
- `./gradlew --version` *(fails: No route to host)*