### PR TITLE
Fix email regex

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -122,6 +122,10 @@ kotlin {
         iosMain.dependencies {
             implementation(libs.coil.multiplatform.network.ktor)
         }
+
+        commonTest.dependencies {
+            implementation(kotlin("test"))
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/core/utils/ValidationUtils.kt
+++ b/composeApp/src/commonMain/kotlin/core/utils/ValidationUtils.kt
@@ -1,6 +1,6 @@
 package core.utils
 
 fun String.isValidEmail(): Boolean {
-    val emailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\$"
+    val emailRegex = """^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$"""
     return matches(emailRegex.toRegex())
-} 
+}

--- a/composeApp/src/commonTest/kotlin/core/utils/ValidationUtilsTest.kt
+++ b/composeApp/src/commonTest/kotlin/core/utils/ValidationUtilsTest.kt
@@ -1,0 +1,17 @@
+package core.utils
+
+import kotlin.test.Test
+import kotlin.test.assertTrue
+import kotlin.test.assertFalse
+
+class ValidationUtilsTest {
+    @Test
+    fun validEmailPasses() {
+        assertTrue("test@example.com".isValidEmail())
+    }
+
+    @Test
+    fun invalidEmailFails() {
+        assertFalse("test@example.com$".isValidEmail())
+    }
+}


### PR DESCRIPTION
## Summary
- use raw regex in `ValidationUtils`
- register Kotlin test dependencies
- add unit tests for email validation

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*