### PR TITLE
Fix platform image picker functions

### DIFF
--- a/composeApp/src/iosMain/kotlin/di/Providers.ios.kt
+++ b/composeApp/src/iosMain/kotlin/di/Providers.ios.kt
@@ -6,6 +6,6 @@ import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.singleton
 
-actual fun DI.Builder.provideImagePicker(platform: Platform) {
+actual fun DI.Builder.provideImagePicker() {
     bind<ImagePicker>() with singleton { IOSImagePicker() }
-} 
+}

--- a/composeApp/src/jvmMain/kotlin/di/Providers.desktop.kt
+++ b/composeApp/src/jvmMain/kotlin/di/Providers.desktop.kt
@@ -6,6 +6,6 @@ import org.kodein.di.DI
 import org.kodein.di.bind
 import org.kodein.di.singleton
 
-actual fun DI.Builder.provideImagePicker(platform: Platform) {
+actual fun DI.Builder.provideImagePicker() {
     bind<ImagePicker>() with singleton { DesktopImagePicker() }
-} 
+}


### PR DESCRIPTION
## Summary
- align `provideImagePicker` actual implementations with expect declaration
- keep signature consistent across platforms

## Testing
- `./gradlew build` *(fails: No route to host)*